### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/InMobiAdapter.swift
+++ b/Source/InMobiAdapter.swift
@@ -47,9 +47,8 @@ final class InMobiAdapter: NSObject, PartnerAdapter {
         // Initialize InMobi
         IMSdk.initWithAccountID(accountID) { [self] partnerError in
             if let partnerError = partnerError {
-                let error = error(.initializationFailureUnknown, error: partnerError)
-                log(.setUpFailed(error))
-                completion(error)
+                log(.setUpFailed(partnerError))
+                completion(partnerError)
             } else {
                 log(.setUpSucceded)
                 completion(nil)

--- a/Source/InMobiAdapterBannerAd.swift
+++ b/Source/InMobiAdapterBannerAd.swift
@@ -71,7 +71,7 @@ extension InMobiAdapterBannerAd: IMBannerDelegate {
     
     func banner(_ banner: IMBanner?, didFailToLoadWithError partnerError: IMRequestStatus?) {
         // Report load failure
-        let error = error(.loadFailureUnknown, error: partnerError)
+        let error = partnerError ?? self.error(.loadFailureUnknown)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil

--- a/Source/InMobiAdapterFullscreenAd.swift
+++ b/Source/InMobiAdapterFullscreenAd.swift
@@ -61,7 +61,7 @@ extension InMobiAdapterFullscreenAd: IMInterstitialDelegate {
     
     func interstitial(_ interstitial: IMInterstitial?, didFailToLoadWithError partnerError: IMRequestStatus?) {
         // Report load failure
-        let error = error(.loadFailureUnknown, error: partnerError)
+        let error = partnerError ?? self.error(.loadFailureUnknown)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil
@@ -76,7 +76,7 @@ extension InMobiAdapterFullscreenAd: IMInterstitialDelegate {
     
     func interstitial(_ interstitial: IMInterstitial?, didFailToPresentWithError partnerError: IMRequestStatus?) {
         // Report show failure
-        let error = error(.showFailureUnknown, error: partnerError)
+        let error = partnerError ?? self.error(.showFailureUnknown)
         log(.showFailed(error))
         showCompletion?(.failure(error)) ?? log(.showResultIgnored)
         showCompletion = nil


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
