### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/InMobiAdapter.swift
+++ b/Source/InMobiAdapter.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/4/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import InMobiSDK
 
 /// The Helium InMobi adapter.

--- a/Source/InMobiAdapterAd.swift
+++ b/Source/InMobiAdapterAd.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/4/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import InMobiSDK
 
 /// Base class for Helium InMobi adapter ads.

--- a/Source/InMobiAdapterBannerAd.swift
+++ b/Source/InMobiAdapterBannerAd.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/4/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import InMobiSDK
 
 /// The Helium InMobi adapter banner ad.

--- a/Source/InMobiAdapterFullscreenAd.swift
+++ b/Source/InMobiAdapterFullscreenAd.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/4/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import InMobiSDK
 
 /// The Helium InMobi adapter fullscreen ad.


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.