### PR TITLE
HB-5512: cherry-pick `CHANGELOG.md` updates from 4.10.1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 
 ### 4.10.1.2.0
 - This version of the adapters has been certified with InMobiSDK 10.1.2.
+
+### 4.10.1.1.0
+- This version of the adapters has been certified with InMobiSDK 10.1.1.


### PR DESCRIPTION
4.10.1.1.0 is a simple backward release (PR #32), thus we only need to cherry-pick `CHANGELOG.md`.