### PR TITLE
[HB-6535] Update InMobi adapter to include bidding APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.10.7.0.1
+- Update to include usage of bidding APIs.
+
 ### 4.10.7.0.0
 - This version of the adapter has been certified with InMobiSDK 10.7.0.
 

--- a/ChartboostMediationAdapterInMobi.podspec
+++ b/ChartboostMediationAdapterInMobi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterInMobi'
-  spec.version     = '4.10.7.0.0'
+  spec.version     = '4.10.7.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-inmobi'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }

--- a/Source/InMobiAdapterAd.swift
+++ b/Source/InMobiAdapterAd.swift
@@ -20,7 +20,10 @@ class InMobiAdapterAd: NSObject {
     /// The partner ad delegate to send ad life-cycle events to.
     /// It should be the one provided on `PartnerAdapter.makeAd(request:delegate:)`.
     weak var delegate: PartnerAdDelegate?
-    
+
+    /// The completion for the ongoing preload operation.
+    var preloadCompletion: ((Result<PartnerEventDetails, Error>) -> Void)?
+
     /// The completion for the ongoing load operation.
     var loadCompletion: ((Result<PartnerEventDetails, Error>) -> Void)?
 

--- a/Source/InMobiPreloadable.swift
+++ b/Source/InMobiPreloadable.swift
@@ -1,0 +1,14 @@
+// Copyright 2022-2024 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import ChartboostMediationSDK
+
+/// A protocol that indicates that an InMobi ad can be preloaded using
+/// their bidding APIs.
+
+protocol InMobiPreloadable {
+    /// Requesting an ad for bid.
+    func preload(completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+}

--- a/Source/InMobiPreloadable.swift
+++ b/Source/InMobiPreloadable.swift
@@ -10,5 +10,5 @@ import ChartboostMediationSDK
 
 protocol InMobiPreloadable {
     /// Requesting an ad for bid.
-    func preload(completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func preload(completion: @escaping (Result<PartnerEventDetails, Error>) -> Void)
 }


### PR DESCRIPTION
Updates InMobi adapter to include bidding APIs. Bumps version of adapter to `4.10.7.0.1`.

Based on this "documentation": https://support.inmobi.com/monetize/other-integrations/audience-bidding-header-bidding/custom-mediation-for-ios