### PR TITLE
Remove PartnerAdapterFormat.adaptive_banner

### DIFF
--- a/Source/InMobiAdapter.swift
+++ b/Source/InMobiAdapter.swift
@@ -116,7 +116,7 @@ final class InMobiAdapter: NSObject, PartnerAdapter {
         switch request.format {
         case PartnerAdFormats.interstitial, PartnerAdFormats.rewarded:
             return try InMobiAdapterFullscreenAd(adapter: self, request: request, delegate: delegate)
-        case PartnerAdFormats.banner, PartnerAdFormats.adaptiveBanner:
+        case PartnerAdFormats.banner:
             return try InMobiAdapterBannerAd(adapter: self, request: request, delegate: delegate)
         default:
             throw error(.loadFailureUnsupportedAdFormat)

--- a/Source/InMobiAdapterBannerAd.swift
+++ b/Source/InMobiAdapterBannerAd.swift
@@ -36,7 +36,7 @@ final class InMobiAdapterBannerAd: InMobiAdapterAd, PartnerAd {
         log(.loadStarted)
 
         // Fail if we cannot fit a fixed size banner in the requested size.
-        guard let size = fixedBannerSize(for: request.size ?? IABStandardAdSize) else {
+        guard let size = fixedBannerSize(for: request.bannerSize) else {
             let error = error(.loadFailureInvalidBannerSize)
             log(.loadFailed(error))
             return completion(.failure(error))
@@ -96,13 +96,16 @@ extension InMobiAdapterBannerAd: IMBannerDelegate {
 
 // MARK: - Helpers
 extension InMobiAdapterBannerAd {
-    private func fixedBannerSize(for requestedSize: CGSize) -> CGSize? {
+    private func fixedBannerSize(for requestedSize: BannerSize?) -> CGSize? {
+        guard let requestedSize else {
+            return IABStandardAdSize
+        }
         let sizes = [IABLeaderboardAdSize, IABMediumAdSize, IABStandardAdSize]
         // Find the largest size that can fit in the requested size.
         for size in sizes {
             // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.width >= size.width &&
-                (size.height == 0 || requestedSize.height >= size.height) {
+            if requestedSize.size.width >= size.width &&
+                (size.height == 0 || requestedSize.size.height >= size.height) {
                 return size
             }
         }


### PR DESCRIPTION
Updated implementation for removal of PartnerAdapterFormats.adaptive_banner and additiong of a BannerSize property in PartnerAdLoadRequest