### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
   release-adapter:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,4 +12,4 @@ jobs:
   validate-podspec:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2

--- a/Source/InMobiAdapter.swift
+++ b/Source/InMobiAdapter.swift
@@ -14,18 +14,26 @@ final class InMobiAdapter: NSObject, PartnerAdapter {
     private let tcfv2Key = "IABTCF_TCString"
 
     /// The version of the partner SDK.
-    let partnerSDKVersion = IMSdk.getVersion()
-    
+    var partnerSDKVersion: String {
+        InMobiAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.10.7.0.0"
-    
+    var adapterVersion: String {
+        InMobiAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "inmobi"
-    
+    var partnerID: String {
+        InMobiAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "InMobi"
+    var partnerDisplayName: String {
+        InMobiAdapterConfiguration.partnerDisplayName
+    }
     
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.

--- a/Source/InMobiAdapterConfiguration.swift
+++ b/Source/InMobiAdapterConfiguration.swift
@@ -1,0 +1,27 @@
+// Copyright 2022-2024 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import Foundation
+import InMobiSDK
+
+/// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
+@objc public class InMobiAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        IMSdk.getVersion()
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.10.7.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "inmobi"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "InMobi"
+}

--- a/Source/InMobiAdapterConfiguration.swift
+++ b/Source/InMobiAdapterConfiguration.swift
@@ -10,18 +10,18 @@ import InMobiSDK
 @objc public class InMobiAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         IMSdk.getVersion()
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.10.7.0.0"
+    @objc public static let adapterVersion = "4.10.7.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "inmobi"
+    @objc public static let partnerID = "inmobi"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "InMobi"
+    @objc public static let partnerDisplayName = "InMobi"
 }


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.