### PR TITLE
[HB-6535] InMobi bid API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.10.7.0.1
+- Update to utilize InMobiSDK bidding APIs.
+
 ### 4.10.7.0.0
 - This version of the adapter has been certified with InMobiSDK 10.7.0.
 

--- a/ChartboostMediationAdapterInMobi.podspec
+++ b/ChartboostMediationAdapterInMobi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterInMobi'
-  spec.version     = '4.10.7.0.0'
+  spec.version     = '4.10.7.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-inmobi'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }

--- a/Source/InMobiAdapter.swift
+++ b/Source/InMobiAdapter.swift
@@ -69,6 +69,7 @@ final class InMobiAdapter: NSObject, PartnerAdapter {
         log(.fetchBidderInfoStarted(request))
         guard let bidToken = IMSdk.getToken() else {
             log(.fetchBidderInfoFailed(request, error: error(.prebidFailureUnknown, description: "Failed to provide bid token.")))
+            completion(nil)
             return
         }
         log(.fetchBidderInfoSucceeded(request))

--- a/Source/InMobiAdapter.swift
+++ b/Source/InMobiAdapter.swift
@@ -31,7 +31,7 @@ final class InMobiAdapter: NSObject, PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.10.7.0.0"
+    let adapterVersion = "4.10.7.0.1"
     
     /// The partner's unique identifier.
     let partnerIdentifier = "inmobi"

--- a/Source/InMobiAdapter.swift
+++ b/Source/InMobiAdapter.swift
@@ -10,17 +10,6 @@ import InMobiSDK
 /// The Chartboost Mediation InMobi adapter.
 final class InMobiAdapter: NSObject, PartnerAdapter {
 
-    /// Specialized error cases for the InMobi adapter.
-    enum InMobiAdapterError: LocalizedError {
-        case failedToProvideBidToken
-
-        var errorDescription: String? {
-            switch self {
-            case .failedToProvideBidToken: return "Failed to provide bid token."
-            }
-        }
-    }
-
     /// This key for the TCFv2 string when stored in UserDefaults is defined by the IAB in Consent Management Platform API Final v.2.2 May 2023
     /// https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-is-the-cmp-in-app-internal-structure-for-the-defined-api
     private let tcfv2Key = "IABTCF_TCString"
@@ -79,7 +68,7 @@ final class InMobiAdapter: NSObject, PartnerAdapter {
     func fetchBidderInformation(request: PreBidRequest, completion: @escaping ([String : String]?) -> Void) {
         log(.fetchBidderInfoStarted(request))
         guard let bidToken = IMSdk.getToken() else {
-            log(.fetchBidderInfoFailed(request, error: InMobiAdapterError.failedToProvideBidToken))
+            log(.fetchBidderInfoFailed(request, error: error(.prebidFailureUnknown, description: "Failed to provide bid token.")))
             return
         }
         log(.fetchBidderInfoSucceeded(request))

--- a/Source/InMobiAdapter.swift
+++ b/Source/InMobiAdapter.swift
@@ -9,6 +9,18 @@ import InMobiSDK
 
 /// The Chartboost Mediation InMobi adapter.
 final class InMobiAdapter: NSObject, PartnerAdapter {
+
+    /// Specialized error cases for the InMobi adapter.
+    enum InMobiAdapterError: LocalizedError {
+        case failedToProvideBidToken
+
+        var errorDescription: String? {
+            switch self {
+            case .failedToProvideBidToken: return "Failed to provide bid token."
+            }
+        }
+    }
+
     /// This key for the TCFv2 string when stored in UserDefaults is defined by the IAB in Consent Management Platform API Final v.2.2 May 2023
     /// https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-is-the-cmp-in-app-internal-structure-for-the-defined-api
     private let tcfv2Key = "IABTCF_TCString"
@@ -65,8 +77,13 @@ final class InMobiAdapter: NSObject, PartnerAdapter {
     /// - parameter request: Information about the ad load request.
     /// - parameter completion: Closure to be performed with the fetched info.
     func fetchBidderInformation(request: PreBidRequest, completion: @escaping ([String : String]?) -> Void) {
-        // InMobi does not currently provide any bidding token
-        completion(nil)
+        log(.fetchBidderInfoStarted(request))
+        guard let bidToken = IMSdk.getToken() else {
+            log(.fetchBidderInfoFailed(request, error: InMobiAdapterError.failedToProvideBidToken))
+            return
+        }
+        log(.fetchBidderInfoSucceeded(request))
+        completion(["token": bidToken])
     }
     
     /// Indicates if GDPR applies or not and the user's GDPR consent status.

--- a/Source/InMobiAdapterBannerAd.swift
+++ b/Source/InMobiAdapterBannerAd.swift
@@ -48,7 +48,11 @@ final class InMobiAdapterBannerAd: InMobiAdapterAd, PartnerAd {
         inlineView = ad
         
         // Load it
-        ad.load()
+        if let adm = request.adm, let data = adm.data(using: .utf8) {
+            ad.load(data)
+        } else {
+            ad.load()
+        }
     }
     
     /// Shows a loaded ad.

--- a/Source/InMobiAdapterFullscreenAd.swift
+++ b/Source/InMobiAdapterFullscreenAd.swift
@@ -9,7 +9,7 @@ import InMobiSDK
 
 /// The Chartboost Mediation InMobi adapter fullscreen ad.
 final class InMobiAdapterFullscreenAd: InMobiAdapterAd, PartnerAd {
-    
+
     /// The partner ad view to display inline. E.g. a banner view.
     /// Should be nil for full-screen ads.
     var inlineView: UIView? { nil }
@@ -34,7 +34,11 @@ final class InMobiAdapterFullscreenAd: InMobiAdapterAd, PartnerAd {
     func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
         log(.loadStarted)
         loadCompletion = completion
-        ad.load()
+        if let adm = request.adm, let data = adm.data(using: .utf8) {
+            ad.load(data)
+        } else {
+            ad.load()
+        }
     }
     
     /// Shows a loaded ad.


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-6535

Bid support with InMobi, SDK 10.7.0.

Their documentation:
[Bidding Integration with InMobi SDK.pdf](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-inmobi/files/15298693/Bidding.Integration.with.InMobi.SDK.pdf)
