### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+All official releases can be found on this repository's [releases page](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-inmobi/releases).
+
 ### 5.10.7.0.0
 - The minimum deployment target compatible with this adapter is now iOS 13.
 - This version of the adapter has been certified with ChartboostMediationSDK 5.0.0.


### PR DESCRIPTION
Retroactively update the CHANGELOG to include a link to the official releases page on Github and with Mediation 4 releases (if necessary).